### PR TITLE
Allow for custom handling of terminal resize signal

### DIFF
--- a/readline.go
+++ b/readline.go
@@ -56,6 +56,7 @@ static void register_readline() {
 import "C"
 
 import (
+	"fmt"
 	"io"
 	"unsafe"
 	"syscall"
@@ -241,6 +242,17 @@ func CatchResize(catch bool) {
 		C.rl_catch_sigwinch = 1
 	} else {
 		C.rl_catch_sigwinch = 0
+	}
+}
+
+// Sets if readline should catch the signals SIGINT, SIGQUIT, SIGTERM,
+// SIGALRM, SIGTSTP, SIGTTIN, and SIGTTOU. See also CatchResize() and
+// Cleanup().
+func CatchSignals(catch bool) {
+	if catch {
+		C.rl_catch_signals = 1
+	} else {
+		C.rl_catch_signals = 0
 	}
 }
 


### PR DESCRIPTION
I found that this was necessary to avoid a crash on SIGWINCH when I resize the terminal during a call to String().

A second patch allows to disable readline's handling of other signals, for completeness
