### PR TITLE
Completion

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -37,14 +37,3 @@ func ExampleCleanup() {
 		fmt.Printf("Read line %s, error %v\n", line, err)
 	}
 }
-
-func ExampleEscapePrompt() {
-	// ANSI escape sequences
-    bright := "\x1b[1m"
-    reset := "\x1b[0m"
-	
-	prompt := readline.EscapePrompt("Command: " + bright)
-	line, err := readline.String(prompt)
-	fmt.Print(reset) // Revert terminal to non-bright text
-	fmt.Printf("Read line %s, error %v\n", line, err)
-}

--- a/readline.go
+++ b/readline.go
@@ -56,7 +56,6 @@ static void register_readline() {
 import "C"
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"os/signal"
@@ -65,19 +64,17 @@ import (
 	"unsafe"
 )
 
-// The default prompt used by Reader().
+// The prompt used by Reader(). The prompt can contain ANSI escape
+// sequences, they will be escaped as necessary.
 var Prompt = "> "
 
-// The continue prompt used by Reader().
+// The continue prompt used by Reader(). The prompt can contain ANSI escape
+// sequences, they will be escaped as necessary.
 var Continue = ".."
 
-// These characters must be used to surround sequences of invisible characters in a prompt. Example:
-// 	bright := "\x1b[1m" // ANSI escape sequence for bright text
-// 	readline.Prompt = fmt.Sprintf("> %c%s%c", readline.PromptStartIgnore, bright, readline.PromptEndIgnore)
-// See also EscapePrompt()
 const (
-	PromptStartIgnore = rune(C.RL_PROMPT_START_IGNORE)
-	PromptEndIgnore = rune(C.RL_PROMPT_END_IGNORE)
+	promptStartIgnore = string(C.RL_PROMPT_START_IGNORE)
+	promptEndIgnore = string(C.RL_PROMPT_END_IGNORE)
 )
 
 // The readline package adds a signal handler for SIGINT at init. If
@@ -158,8 +155,11 @@ func (r *reader) Read(buf []byte) (int, error) {
 	return l, nil
 }
 
-// Read a line with the given prompt.
+// Read a line with the given prompt. The prompt can contain ANSI
+// escape sequences, they will be escaped as necessary.
 func String(prompt string) (string, error) {
+	prompt = "\x1b[0m" + prompt // Prepend a 'reset' ANSI escape sequence
+	prompt = escapeSeq.ReplaceAllString(prompt, promptStartIgnore + "$0" + promptEndIgnore)
 	p := C.CString(prompt)
 	rp := C.readline(p)
 	s := C.GoString(rp)
@@ -283,12 +283,6 @@ func Cleanup() {
 	C.rl_cleanup_after_signal()
 }
 
-// Returns a copy of s with all ANSI escape sequences surrounded by
-// PromptStartIgnore and PromptEndIgnore characters
-func EscapePrompt(s string) string {
-	return escapeSeq.ReplaceAllString(s, string(PromptStartIgnore) + "$0" + string(PromptEndIgnore))
-}
-
 func handleSignals() {
 	C.rl_catch_signals = 0
 	C.rl_catch_sigwinch = 0
@@ -299,9 +293,6 @@ func handleSignals() {
 	for s := range signals {
 		switch s {
 		case syscall.SIGWINCH:
-			// Print the 'reset' ANSI escape code, so that the current prompt
-			// ANSI codes won't corrupt the start of the refreshed prompt
-			fmt.Print("\x1b[0m")
 			C.rl_resize_terminal()
 
 		case syscall.SIGINT:


### PR DESCRIPTION
Added a FilenameCompleter() function wrapping the corresponding functionality from readline. For example I have a completer function that uses it  to get a list of files, and filter the list to keep only files with the desired extension. FilenameCompleter() could be implemented in Go, but wrapping the readline version ensures it behaves consistently with the library, e.g. can be configured through readline configuration.

I also removed the use of rl_completion_suppress_append, instead setting rl_completion_append_char to 0 (by default) or the value supplied by the user, for more flexibility.

Finally, simplified the code a bit, caling escapePrompt() systematically instead of exposing it to the user. I think the performance hit is insignificant and the API nicer this way. Also a 'reset' ANSI sequence is now always prefixed. This is a simple way to ensure the prompt is never corrupted by its own escape sequences after a resize or a completion display.
